### PR TITLE
chore!: migrate to node:test, require Node >=22

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,5 +17,5 @@ jobs:
   test:
     uses: voxpelli/ghatemplates/.github/workflows/test.yml@main
     with:
-      node-versions: '18,20,22'
+      node-versions: '22,24,26'
       os: 'ubuntu-latest'

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Pelle Wessman <pelle@kodfabrik.se> (http://kodfabrik.se/)",
   "license": "MIT",
   "engines": {
-    "node": ">=18.6.0"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "type": "module",
   "exports": "./index.js",
@@ -35,7 +35,7 @@
     "clean": "run-p clean:*",
     "prepare": "husky",
     "prepublishOnly": "run-s build",
-    "test:mocha": "c8 --reporter=lcov --reporter text mocha 'test/**/*.spec.js'",
+    "test:node": "c8 --reporter=lcov --reporter text node --test test/*.spec.js",
     "test-ci": "run-s test:*",
     "test": "run-s check test:*"
   },
@@ -45,25 +45,19 @@
     "read-pkg": "^9.0.1"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.19",
-    "@types/chai-as-promised": "^7.1.8",
-    "@types/mocha": "^10.0.8",
-    "@types/node": "^18.19.50",
+    "@types/node": "^22.20.1",
     "@types/npmcli__map-workspaces": "^3.0.4",
     "@voxpelli/eslint-config": "^22.1.0",
-    "@voxpelli/tsconfig": "^14.0.0",
+    "@voxpelli/tsconfig": "^16.2.1",
     "c8": "^10.1.2",
-    "chai": "^4.5.0",
-    "chai-as-promised": "^7.1.2",
     "desm": "^1.3.1",
     "eslint": "^9.10.0",
     "husky": "^9.1.6",
     "installed-check": "^9.3.0",
     "knip": "^5.30.2",
-    "mocha": "^10.7.3",
     "npm-run-all2": "^6.2.2",
     "type-coverage": "^2.29.1",
-    "typescript": "~5.5.3",
+    "typescript": "~6.0.3",
     "validate-conventional-commit": "^1.0.4"
   }
 }

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -1,42 +1,41 @@
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { join } from 'desm';
 
 import { readWorkspaces } from '../index.js';
 import { pkgResult, workspaceAResult, workspaceZResult, pnpmPkgResult } from './fixtures/lookup.js';
 
-chai.use(chaiAsPromised);
+/**
+ * @param {import('../index.js').Options} [options]
+ * @returns {Promise<Array<import('../index.js').Workspace>>}
+ */
+async function collectWorkspaces (options) {
+  /** @type {Array<import('../index.js').Workspace>} */
+  const data = [];
 
-const should = chai.should();
+  for await (const item of readWorkspaces(options)) {
+    data.push(item);
+  }
+
+  return data;
+}
 
 describe('readWorkspaces', () => {
   it('should return data', async () => {
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
+    const data = await collectWorkspaces();
 
-    for await (const item of readWorkspaces()) {
-      data.push(item);
-    }
-
-    data.should.have.length(1);
+    assert.strictEqual(data.length, 1);
 
     for (const item of data) {
-      item.should.be.an('object')
-        .with.keys('cwd', 'pkg')
-        .and.have.nested.property('pkg.name', 'read-workspaces');
+      assert.deepStrictEqual(Object.keys(item).sort(), ['cwd', 'pkg']);
+      assert.strictEqual(item.pkg.name, 'read-workspaces');
     }
   });
 
   it('should return data from cwd when specified', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd })) {
-      data.push(item);
-    }
-
-    data.should.have.length(3).and.deep.equal([
+    assert.deepStrictEqual(await collectWorkspaces({ cwd }), [
       pkgResult(cwd),
       workspaceAResult(cwd),
       workspaceZResult(cwd),
@@ -46,44 +45,25 @@ describe('readWorkspaces', () => {
   it('should error on missing package.json file', async () => {
     const cwd = join(import.meta.url, 'fixtures/missing-package-json');
 
-    await Promise.resolve().then(async () => {
-      /** @type {Array<import('../index.js').Workspace>} */
-      const data = [];
-
-      for await (const item of readWorkspaces({ cwd })) {
-        data.push(item);
-      }
-
-      return data;
-    })
-      .should.be.rejectedWith(/Failed to read package\.json/);
+    await assert.rejects(
+      () => collectWorkspaces({ cwd }),
+      /Failed to read package\.json/
+    );
   });
 
   it('should error on duplicate workspace names', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace-with-build-output');
-    await Promise.resolve().then(async () => {
-      /** @type {Array<import('../index.js').Workspace>} */
-      const data = [];
 
-      for await (const item of readWorkspaces({ cwd })) {
-        data.push(item);
-      }
-
-      return data;
-    })
-      .should.be.rejectedWith(/must not have multiple workspaces with the same name/);
+    await assert.rejects(
+      () => collectWorkspaces({ cwd }),
+      /must not have multiple workspaces with the same name/
+    );
   });
 
   it('should ignore empty workspace filter', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd, workspace: [] })) {
-      data.push(item);
-    }
-
-    data.should.have.length(3).and.deep.equal([
+    assert.deepStrictEqual(await collectWorkspaces({ cwd, workspace: [] }), [
       pkgResult(cwd),
       workspaceAResult(cwd),
       workspaceZResult(cwd),
@@ -92,14 +72,8 @@ describe('readWorkspaces', () => {
 
   it('should include workspaces when requested by name', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd, workspace: ['@voxpelli/workspace-a'] })) {
-      data.push(item);
-    }
-
-    data.should.have.length(2).and.deep.equal([
+    assert.deepStrictEqual(await collectWorkspaces({ cwd, workspace: ['@voxpelli/workspace-a'] }), [
       pkgResult(cwd),
       workspaceAResult(cwd),
     ]);
@@ -107,14 +81,8 @@ describe('readWorkspaces', () => {
 
   it('should include workspaces when requested by exact absolute path', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd, workspace: [`${cwd}/packages/a`] })) {
-      data.push(item);
-    }
-
-    data.should.have.length(2).and.deep.equal([
+    assert.deepStrictEqual(await collectWorkspaces({ cwd, workspace: [`${cwd}/packages/a`] }), [
       pkgResult(cwd),
       workspaceAResult(cwd),
     ]);
@@ -122,14 +90,8 @@ describe('readWorkspaces', () => {
 
   it('should include workspaces when requested by exact relative path', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd, workspace: ['packages/a'] })) {
-      data.push(item);
-    }
-
-    data.should.have.length(2).and.deep.equal([
+    assert.deepStrictEqual(await collectWorkspaces({ cwd, workspace: ['packages/a'] }), [
       pkgResult(cwd),
       workspaceAResult(cwd),
     ]);
@@ -137,14 +99,8 @@ describe('readWorkspaces', () => {
 
   it('should include workspaces when requested by path prefix', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd, workspace: [`${cwd}/packages`] })) {
-      data.push(item);
-    }
-
-    data.should.have.length(3).and.deep.equal([
+    assert.deepStrictEqual(await collectWorkspaces({ cwd, workspace: [`${cwd}/packages`] }), [
       pkgResult(cwd),
       workspaceAResult(cwd),
       workspaceZResult(cwd),
@@ -156,22 +112,24 @@ describe('readWorkspaces', () => {
     /** @type {Array<import('../index.js').Workspace>} */
     const data = [];
 
-    /** @type {any} */
-    let referenceErr;
-
-    try {
-      for await (const item of readWorkspaces({ cwd, workspace: ['packages/a', 'packages/b'] })) {
-        data.push(item);
+    await assert.rejects(
+      async () => {
+        for await (const item of readWorkspaces({ cwd, workspace: ['packages/a', 'packages/b'] })) {
+          data.push(item);
+        }
+      },
+      /**
+       * @param {unknown} err
+       * @returns {boolean}
+       */
+      err => {
+        assert.ok(err instanceof Error);
+        assert.strictEqual(err.message, 'Couldn\'t find all workspaces, missing: packages/b');
+        return true;
       }
-    } catch (err) {
-      referenceErr = err;
-    }
+    );
 
-    should.exist(referenceErr);
-
-    referenceErr.should.be.an('error').with.property('message', 'Couldn\'t find all workspaces, missing: packages/b');
-
-    data.should.have.length(2).and.deep.equal([
+    assert.deepStrictEqual(data, [
       pkgResult(cwd),
       workspaceAResult(cwd),
     ]);
@@ -179,42 +137,24 @@ describe('readWorkspaces', () => {
 
   it('should respect "skipWorkspaces"', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd, skipWorkspaces: true })) {
-      data.push(item);
-    }
-
-    data.should.have.length(1).and.deep.equal([
+    assert.deepStrictEqual(await collectWorkspaces({ cwd, skipWorkspaces: true }), [
       pkgResult(cwd),
     ]);
   });
 
   it('should have "skipWorkspaces" skip workspaces even when workspaces are specifically sent in', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd, skipWorkspaces: true, workspace: ['@voxpelli/workspace-a'] })) {
-      data.push(item);
-    }
-
-    data.should.have.length(1).and.deep.equal([
+    assert.deepStrictEqual(await collectWorkspaces({ cwd, skipWorkspaces: true, workspace: ['@voxpelli/workspace-a'] }), [
       pkgResult(cwd),
     ]);
   });
 
   it('should respect "includeWorkspaceRoot"', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd, includeWorkspaceRoot: false })) {
-      data.push(item);
-    }
-
-    data.should.have.length(2).and.deep.equal([
+    assert.deepStrictEqual(await collectWorkspaces({ cwd, includeWorkspaceRoot: false }), [
       workspaceAResult(cwd),
       workspaceZResult(cwd),
     ]);
@@ -222,26 +162,14 @@ describe('readWorkspaces', () => {
 
   it('should respect both "includeWorkspaceRoot" and "skipWorkspaces" at once', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd, includeWorkspaceRoot: false, skipWorkspaces: true })) {
-      data.push(item);
-    }
-
-    data.should.have.length(0).and.deep.equal([]);
+    assert.deepStrictEqual(await collectWorkspaces({ cwd, includeWorkspaceRoot: false, skipWorkspaces: true }), []);
   });
 
   it('should respect "ignorePaths"', async () => {
     const cwd = join(import.meta.url, 'fixtures/workspace-with-build-output');
-    /** @type {Array<import('../index.js').Workspace>} */
-    const data = [];
 
-    for await (const item of readWorkspaces({ cwd, ignorePaths: ['**/build/**'] })) {
-      data.push(item);
-    }
-
-    data.should.have.length(3).and.deep.equal([
+    assert.deepStrictEqual(await collectWorkspaces({ cwd, ignorePaths: ['**/build/**'] }), [
       pkgResult(cwd, { workspaces: ['packages/**'] }),
       workspaceAResult(cwd),
       workspaceZResult(cwd),
@@ -251,14 +179,8 @@ describe('readWorkspaces', () => {
   describe('pnpm', () => {
     it('should resolve pnpm workspaces', async () => {
       const cwd = join(import.meta.url, 'fixtures/pnpm-workspace');
-      /** @type {Array<import('../index.js').Workspace>} */
-      const data = [];
 
-      for await (const item of readWorkspaces({ cwd })) {
-        data.push(item);
-      }
-
-      data.should.have.length(3).and.deep.equal([
+      assert.deepStrictEqual(await collectWorkspaces({ cwd }), [
         pnpmPkgResult(cwd),
         workspaceAResult(cwd),
         workspaceZResult(cwd),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@voxpelli/tsconfig/node18.json",
+  "extends": "@voxpelli/tsconfig/node22.json",
   "files": [
     "index.js"
   ],
@@ -9,6 +9,6 @@
   "compilerOptions": {
     // Needed because @types/npmcli__map-workspaces tries to import a non-existing IGlobal from "glob"
     "skipLibCheck": true,
-    "types": ["node", "mocha"]
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
Replace `mocha` and `chai` with the built-in `node:test` runner and `node:assert/strict`. Rewrite all assertions in `test/main.spec.js` to use the standard library and extract a shared `collectWorkspaces` helper to reduce repetition.

Bump the minimum supported Node.js from `>=18.6.0` to `^22.13.0 || >=24.0.0`, aligning CI matrix (`22,24,26`), `tsconfig` base (`node22`), `@types/node`, `@voxpelli/tsconfig`, and `typescript` to match. Remove `@types/chai`, `@types/chai-as-promised`, `@types/mocha`, `chai`, `chai-as-promised`, and `mocha` from devDependencies.

BREAKING CHANGE: drops support for Node.js 18 and 20; minimum is now Node.js 22.13.0.